### PR TITLE
Update jq installing method

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,18 +2,14 @@ FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.9
 
 USER root
 
-ENV JQ_VERSION 1.5
-ENV JQ_SHA256 c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
-RUN cd /tmp \
-    && curl -o /usr/bin/jq -SL "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" \
-    && echo "$JQ_SHA256  /usr/bin/jq" | sha256sum -c - \
-    && chmod +x /usr/bin/jq
-
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
-RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+RUN yum install -y epel-release \
+    && yum install -y jq \
+    && yum clean all \
+    && chown elasticsearch:elasticsearch config/elasticsearch.yml
 
 USER elasticsearch
 
 RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.6.9.2
-


### PR DESCRIPTION
Because the elastic image base on centos we should use yum if possible (package trusted repo).